### PR TITLE
Some optimizations for gopheragent.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+main/main

--- a/main/main.go
+++ b/main/main.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"github.com/remind101/gopheragent"
+)
+
+// the 100 most common user_agent strings in our event data.
+var agents = []string{
+	"Faraday v0.8.11",
+	"Remind101/1236706 (iPhone8,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone7,2; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,2; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone9,2; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone9,3; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone6,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,4; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone7,1; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone7,2; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,1; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,4; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone6,1; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,1; iOS 10.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,2; iOS 10.2.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone9,1; iOS 10.2.1; Scale/2.00)",
+	"Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+	"Remind101/1236706 (iPhone8,1; iOS 10.3.2; Scale/2.00)",
+	"Remind101/1216345 (iPhone8,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone7,1; iOS 10.2.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone7,2; iOS 10.2; Scale/2.00)",
+	"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+	"Remind101/1236706 (iPhone7,2; iOS 10.3.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,3; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1216345 (iPhone7,2; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,2; iOS 10.2.1; Scale/3.00)",
+	"Go-http-client/1.1",
+	"Remind101/1236706 (iPhone9,4; iOS 10.2.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone5,3; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone7,2; iOS 10.1.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone5,3; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,4; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,2; iOS 10.3.2; Scale/3.00)",
+	"Remind101/1236706 (iPhone7,2; iOS 10.0.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,1; iOS 10.1.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,1; iOS 10.2; Scale/2.00)",
+	"Remind101/1216345 (iPhone9,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1196288 (iPhone8,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1216345 (iPhone8,2; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone6,1; iOS 10.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,1; iOS 10.0.2; Scale/2.00)",
+	"Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_1 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.0 Mobile/14E304 Safari/602.1",
+	"Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+	"Remind101/1236706 (iPhone8,2; iOS 10.2; Scale/3.00)",
+	"Remind101/1236706 (iPhone9,1; iOS 10.3.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,4; iOS 10.3.2; Scale/3.00)",
+	"Remind101/1236706 (iPhone5,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,2; iOS 10.3.2; Scale/3.00)",
+	"Remind101/1216345 (iPhone9,2; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1196288 (iPhone7,2; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,3; iOS 10.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone7,1; iOS 10.3.2; Scale/3.00)",
+	"Remind101/1236706 (iPad5,3; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1175977 (iPhone8,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,3; iOS 10.3.2; Scale/2.00)",
+	"Remind101/1137190 (iPhone8,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1216345 (iPhone8,1; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1216345 (iPhone9,3; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone4,1; iOS 9.3.5; Scale/2.00)",
+	"Remind101/1236706 (iPhone5,2; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1216345 (iPhone9,4; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1236706 (iPod7,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPad4,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1216345 (iPhone7,2; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,2; iOS 10.2; Scale/3.00)",
+	"Remind101/1236706 (iPod5,1; iOS 9.3.5; Scale/2.00)",
+	"Remind101/1236706 (iPhone7,2; iOS 10.0.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,4; iOS 10.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone7,1; iOS 10.2; Scale/3.00)",
+	"Remind101/1236706 (iPhone6,1; iOS 10.1.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone6,1; iOS 10.3.2; Scale/2.00)",
+	"Remind101/1216345 (iPhone7,1; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone9,1; iOS 10.1.1; Scale/2.00)",
+	"Remind101/1196288 (iPhone9,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,1; iOS 10.0.1; Scale/2.00)",
+	"Remind101/1175977 (iPhone7,2; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1137190 (iPhone7,2; iOS 10.3.1; Scale/2.00)",
+	"Mozilla/5.0 (Windows NT 6.3; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+	"Remind101/1216345 (iPhone6,1; iOS 10.3.1; Scale/2.00)",
+	"Dalvik/2.1.0 (Linux; U; Android 7.0; SM-G930V Build/NRD90M)",
+	"Remind101/1236706 (iPhone9,4; iOS 10.2; Scale/3.00)",
+	"Remind101/1236706 (iPhone7,1; iOS 10.1.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone7,2; iOS 9.3.5; Scale/2.00)",
+	"Remind101/1216345 (iPhone8,4; iOS 10.3.1; Scale/2.00)",
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4) AppleWebKit/603.1.30 (KHTML, like Gecko) Version/10.1 Safari/603.1.30",
+	"Remind101/1196288 (iPhone8,2; iOS 10.3.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone8,2; iOS 10.1.1; Scale/3.00)",
+	"Remind101/1236706 (iPhone6,1; iOS 10.0.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone8,4; iOS 10.3.2; Scale/2.00)",
+	"Remind101/1236706 (iPhone9,3; iOS 10.1.1; Scale/2.00)",
+	"Remind101/1236706 (iPhone7,1; iOS 10.0.2; Scale/3.00)",
+	"Remind101/1175977 (iPhone9,1; iOS 10.3.1; Scale/2.00)",
+	"Remind101/1196288 (iPhone7,2; iOS 10.2.1; Scale/2.00)",
+	"Remind101/1162141 (iPhone8,1; iOS 10.3.1; Scale/2.00)",
+	"Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko",
+	"Dalvik/2.1.0 (Linux; U; Android 7.0; SM-G920V Build/NRD90M)",
+	"Remind101/1196288 (iPhone8,1; iOS 10.2.1; Scale/2.00)",
+	"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.36",
+}
+
+// An unrealistic benchmark.
+func test_gopheragent() {
+	for i := 0; i < 1000; i++ {
+		for _, agent := range agents {
+			ua := gopheragent.New(agent)
+			ua.BrowserName()
+			ua.BrowserVersion()
+			ua.Engine()
+			ua.EngineVersion()
+			ua.Mobile()
+			ua.OS()
+			ua.Platform()
+		}
+	}
+}
+
+func main() {
+	test_gopheragent()
+}


### PR DESCRIPTION
I added a benchmark: repeatedly parsing our 100 most common user-agent strings.  (This maybe isn't *that* unrealistic, as the distribution of user-agent strings is quite skewed toward the most common user-agents.)
 
The other changes in this PR reduce the time to run that benchmark from about 13s down to about 4.5s on my MacBook.

Basically the gopheragent matches strings against chains of regexps. A very significant number of user_agents don't match *any* of those regexps, which means the fewer regexps in the chain, the better off we are. So I removed a bunch of regexps for browsers/engines/oses we basically never encounter in real life. I also in some cases moved more common items up the list so they would be more likely to match first.

A constraint on this PR is that I wanted all the existing tests to still pass. That's because there are tons of test cases and if I start getting failures I don't really have time to think about whether that represents a real problem or just because our tests are too specific (as I believe some of them may be). Luckily, most of our seldom-encountered browsers etc were absent from the test suite.

NOTE: I also tried plugging in `uap-go` (the golang implementation of ua-parser) and benchmarking it vs gopheragent, just to see how it would do (even though it doesn't parse all the same categories of information out of the user-agent string and therefore wouldn't be a plug-and-play replacement for gopheragent). It actually ran 4x slower!  It seems like it takes the same basic approach of testing the string against a list of regexps... but with a more comprehensive list. :(

NOTE also that gopheragent is currently only used by r101-etl AFAICT.
